### PR TITLE
Improve font management, add standard stacks

### DIFF
--- a/src/style/_/modules/text/domains/body.styl
+++ b/src/style/_/modules/text/domains/body.styl
@@ -2,4 +2,4 @@
 
 html
     font-size: (base)px
-    font-family: sans_serif
+    font-family: $sans-serif

--- a/src/style/_/modules/text/domains/forms.styl
+++ b/src/style/_/modules/text/domains/forms.styl
@@ -1,4 +1,4 @@
 /*━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  FORMS  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━*/
 
 button, input, select, textarea
-    font-family: sans_serif
+    font-family: $sans-serif

--- a/src/style/_/modules/text/domains/headings.styl
+++ b/src/style/_/modules/text/domains/headings.styl
@@ -1,7 +1,7 @@
 /*━━━━━━━━━━━━━━━━━━━━━━━━━━━━  HEADINGS  ━━━━━━━━━━━━━━━━━━━━━━━━━━*/
 
 h1, h2, h3, h4, h5, h6
-    font-family: sans_serif
+    font-family: $sans-serif
     font-weight: bold
     color: _heading
     span, a

--- a/src/style/_/modules/text/domains/monospaced.styl
+++ b/src/style/_/modules/text/domains/monospaced.styl
@@ -5,6 +5,6 @@ pre
     word-wrap: break-word
 
 code, kbd, pre, samp
-    font-family: monospaced
+    font-family: $monospace
     font-size: .9rem
     color: _code

--- a/src/style/_/modules/text/stacks.styl
+++ b/src/style/_/modules/text/stacks.styl
@@ -2,28 +2,51 @@
 ┃ Manage font stacks.                                                ┃
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━*/
 
-avec_serif = 'Crimson Text',
-             'Libre Baskerville',
-             'Noto Serif',
-             'Butler',
-             'Arvo',
-             'Georgia',
-             serif
+$serif      = 'Sitka',
+              'Athe­las',
+              'Crimson Text',
+              'Libre Baskerville',
+              'Noto Serif',
+              'Butler',
+              'Garamond',
+              'Palatino Linotype',
+              'Bell MT',
+              'Char­ter',
+              serif
 
-sans_serif = 'Roboto',
-             'Open Sans',
-             'Noto Sans',
-             'Fira Sans',
-             'Source Sans Pro',
-             'Helvetica Neue',
-             'Helvetica',
-             'Arial',
-             sans-serif
+$sans-serif = 'Open Sans',
+              'Noto Sans',
+              'Fira Sans',
+              'Source Sans Pro',
+              'Helvetica Neue',
+              'Helvetica',
+              'Ser­avek',
+              'Avenir',
+              'Franklin Gothic',
+              'Arial',
+              sans-serif
 
-monospaced = 'Hack',
-             'Source Code Pro',
-             'Anonymous Pro',
-             'Fira Mono',
-             'Monaco',
-             'Courier',
-             monospace
+$monospace  = 'Hack',
+              'Source Code Pro',
+              'Anonymous Pro',
+              'Fira Mono',
+              'Monaco',
+              'Courier',
+              monospace
+
+$cursive    = 'Pacifico',
+              'Brush Script MT',
+              'Lucida Calligraphy',
+              'Lucida Handwriting',
+              'Apple Chancery',
+              cursive
+
+$fantasy    = 'Eras ITC',
+              'Impact',
+              'Haettenschweiler',
+              'Marker Felt',
+              'Brushstroke',
+              'Harrington',
+              'Luminari',
+              'Trattatello',
+              fantasy


### PR DESCRIPTION
## Description
Address issue #3  

**Additional change:**
Prefixing allow stack names to be verbatim refs to the standard CSS font idents.
Changed accordingly to make it easier to remember the common font stack variables  
Ie.: `avec_serif` -> `$serif` etc.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **CONTRIBUTING** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
